### PR TITLE
Hoists `taints` block of the `aws_eks_node_group` as a variable

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -31,6 +31,15 @@ resource "aws_eks_node_group" "node_group" {
     max_unavailable_percentage = lookup(each.value, "update_unavailable_percent", 50)
   }
 
+  dynamic "taint" {
+    for_each = lookup(each.value, "taints", [])
+    content {
+      key    = taint.value["key"]
+      value  = taint.value["value"]
+      effect = taint.value["effect"]
+    }
+  }
+
   tags = merge(
     local.tags,
     {

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -35,7 +35,7 @@ resource "aws_eks_node_group" "node_group" {
     for_each = lookup(each.value, "taints", [])
     content {
       key    = taint.value["key"]
-      value  = taint.value["value"]
+      value  = lookup(taint.value, "value", null)
       effect = taint.value["effect"]
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -367,7 +367,7 @@ variable "karpenter_enabled" {
 }
 
 variable "karpenter_version" {
-  default     = "v0.32.1"
+  default     = "v0.32.2"
   description = "The version of the karpenter helm chart"
 }
 


### PR DESCRIPTION
Allows downstream configuration of EKS Node Kubernetes Taints, as such:

```hcl
{
  instance_types = [
    "g4dn.xlarge",
  ]
  ami_type               = "BOTTLEROCKET_x86_64_NVIDIA"
  nodes_in_public_subnet = true
  node_disk_size         = 50,
  node_desired_capacity  = 1,
  nodes_max_size         = 1,
  nodes_min_size         = 1
  taints = [
    {
      key : "GPU",
      value : "true",
      effect : "NO_SCHEDULE"
    }
  ]
}
```